### PR TITLE
Fix README path typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 uv run langfuse-cli -d
 
-This will download all datasets from langfuse into root/datasts directory.
+This will download all datasets from langfuse into root/datasets directory.
 
 
 ## Up 


### PR DESCRIPTION
## Summary
- fix a typo in README referencing the datasets directory

## Testing
- `pytest -q` *(fails: command not found)*